### PR TITLE
fix: Improve mousehole fallback handling and UI feedback

### DIFF
--- a/app/api/mam-token/route.js
+++ b/app/api/mam-token/route.js
@@ -62,7 +62,11 @@ export async function GET() {
       token: maskToken(token),
       fullLength: token.length,
       location: MAM_TOKEN_FILE,
-      mouseholeInfo: { enabled: false },
+      mouseholeInfo: mouseholeEnabled ? { 
+        enabled: true, 
+        usingFallback: true,
+        error: "state.json not found, using fallback token file" 
+      } : { enabled: false },
     });
   } catch (error) {
     console.error(`Failed to read MAM token: ${error.message}`);

--- a/app/components/TokenManager.jsx
+++ b/app/components/TokenManager.jsx
@@ -116,28 +116,53 @@ export default function TokenManager({ onTokenUpdate }) {
       {isMouseholeMode ? (
         // Mousehole Read-Only View
         <div className="space-y-4">
-          <div className="p-4 bg-purple-50 border border-purple-200 rounded-md">
-            <div className="flex items-start gap-3">
-              <div className="flex-shrink-0 mt-1">
-                <svg className="w-5 h-5 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
-                </svg>
-              </div>
-              <div className="flex-1">
-                <h3 className="text-sm font-semibold text-purple-900 mb-1">
-                  Token Managed by Mousehole
-                </h3>
-                <p className="text-sm text-purple-700">
-                  Your MAM token is dynamically managed by the mousehole service. Token editing is disabled.
-                </p>
+          {tokenData.mouseholeInfo?.usingFallback ? (
+            // Fallback Warning Banner
+            <div className="p-4 bg-yellow-50 border border-yellow-200 rounded-md">
+              <div className="flex items-start gap-3">
+                <div className="flex-shrink-0 mt-1">
+                  <svg className="w-5 h-5 text-yellow-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                  </svg>
+                </div>
+                <div className="flex-1">
+                  <h3 className="text-sm font-semibold text-yellow-900 mb-1">
+                    Mousehole State File Not Found
+                  </h3>
+                  <p className="text-sm text-yellow-700">
+                    Mousehole mode is enabled, but the state.json file couldn&apos;t be found. Using fallback token from static file.
+                  </p>
+                  <p className="text-xs text-yellow-600 mt-2">
+                    Verify that mousehole is running and the volume mount is correct.
+                  </p>
+                </div>
               </div>
             </div>
-          </div>
+          ) : (
+            // Normal Mousehole Banner
+            <div className="p-4 bg-purple-50 border border-purple-200 rounded-md">
+              <div className="flex items-start gap-3">
+                <div className="flex-shrink-0 mt-1">
+                  <svg className="w-5 h-5 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+                  </svg>
+                </div>
+                <div className="flex-1">
+                  <h3 className="text-sm font-semibold text-purple-900 mb-1">
+                    Token Managed by Mousehole
+                  </h3>
+                  <p className="text-sm text-purple-700">
+                    Your MAM token is dynamically managed by the mousehole service. Token editing is disabled.
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
 
           <div className="p-3 bg-gray-50 rounded-md">
             <p className="text-sm text-gray-600 mb-2">
-              Status: <span className="font-medium text-green-600">
-                {tokenData.exists ? 'Token active' : 'Waiting for mousehole...'}
+              Status: <span className={`font-medium ${tokenData.exists ? 'text-green-600' : 'text-red-600'}`}>
+                {tokenData.exists ? (tokenData.mouseholeInfo?.usingFallback ? 'Using fallback token' : 'Token active') : 'Waiting for mousehole...'}
               </span>
             </p>
             {tokenData.exists && (
@@ -158,8 +183,13 @@ export default function TokenManager({ onTokenUpdate }) {
               </>
             )}
             <p className="text-xs text-gray-500 mt-2">
-              Source: <code className="bg-gray-200 px-1 rounded">{tokenData.mouseholeInfo?.stateFile || tokenData.location}</code>
+              Source: <code className="bg-gray-200 px-1 rounded">{tokenData.location}</code>
             </p>
+            {tokenData.mouseholeInfo?.error && (
+              <p className="text-xs text-red-600 mt-1">
+                {tokenData.mouseholeInfo.error}
+              </p>
+            )}
           </div>
 
           <div className="py-4 px-6 bg-blue-50 rounded-md">


### PR DESCRIPTION
## Summary

Fixes the mousehole fallback UI to properly display when `state.json` is not found and Scurry falls back to the static token file.

## Problem

When `MOUSEHOLE_ENABLED=true` but the `state.json` file doesn't exist (e.g., mousehole not running or volume mount incorrect), the UI showed:
- Status: "Waiting for mousehole..."
- Source: `secrets/mam_api_token` (confusing - shows static file but implies waiting for mousehole)
- No indication that fallback is being used

## Solution

### API Changes (`app/api/mam-token/route.js`)
- Added `usingFallback: true` flag to `mouseholeInfo` when falling back to static token
- Added descriptive error message: "state.json not found, using fallback token file"
- Ensures fallback response includes proper mousehole metadata

### UI Changes (`app/components/TokenManager.jsx`)
- Added yellow warning banner when `usingFallback` is true
- Shows clear message: "Mousehole State File Not Found"
- Explains that static fallback token is being used
- Provides troubleshooting hint about volume mounts
- Status now shows "Using fallback token" instead of "Waiting for mousehole..."
- Displays correct source file path regardless of mode

## After Fix

The UI now clearly shows:
- ⚠️ Yellow warning banner explaining the fallback state
- Status: "Using fallback token"
- Source: `secrets/mam_api_token` (accurate)
- Helpful hint to verify mousehole is running and volumes are mounted correctly

## Testing

- ✅ Mousehole enabled with valid state.json → Shows purple banner
- ✅ Mousehole enabled without state.json → Shows yellow warning banner
- ✅ Mousehole disabled → Shows normal manual management UI
- ✅ Fallback token works correctly for API calls

Fixes the issue shown in production where the UI was confusing when mousehole wasn't available.