### PR TITLE
Fix: Eliminate 'fetch failed' error in FL wedge purchases

### DIFF
--- a/app/api/use-wedge/route.js
+++ b/app/api/use-wedge/route.js
@@ -1,7 +1,5 @@
 import { NextResponse } from "next/server";
-import { readMamToken } from "@/src/lib/config";
-import { MAM_BASE } from "@/src/lib/constants";
-import { generateTimestamp } from "@/src/lib/utilities";
+import { purchaseFlWedge } from "@/src/lib/wedge";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -10,82 +8,19 @@ export async function POST(req) {
   try {
     const { torrentId } = await req.json();
     
-    if (!torrentId) {
-      return NextResponse.json(
-        { error: "Torrent ID is required" },
-        { status: 400 }
-      );
-    }
-
-    const token = readMamToken();
-    const timestamp = generateTimestamp();
-
-    // Call MAM bonus buy API to purchase freeleech wedge
-    const wedgeUrl = `${MAM_BASE}/json/bonusBuy.php/${timestamp}?spendtype=personalFL&torrentid=${torrentId}&timestamp=${timestamp}`;
+    const result = await purchaseFlWedge(torrentId);
     
-    console.log(`Attempting to use FL wedge for torrent ${torrentId}`);
-
-    const res = await fetch(wedgeUrl, {
-      method: "GET",
-      headers: {
-        "Accept": "application/json, text/plain, */*",
-        "Cookie": `mam_id=${token}`,
-        "Origin": "https://www.myanonamouse.net",
-        "Referer": "https://www.myanonamouse.net/"
-      },
-      cache: "no-store"
-    });
-
-    if (!res.ok) {
-      const text = await res.text().catch(() => "");
-      console.error(`Failed to purchase FL wedge: ${res.status} - ${text}`);
-      
-      // Check for MAM token expiration
-      if (res.status === 403 && text.toLowerCase().includes("you are not signed in")) {
-        return NextResponse.json(
-          { 
-            error: "Your MAM token has expired or is invalid. Please update your token.",
-            tokenExpired: true
-          },
-          { status: 401 }
-        );
-      }
-      
+    if (!result.success) {
       return NextResponse.json(
-        { error: `Failed to purchase FL wedge: ${res.status}` },
-        { status: 502 }
+        { error: result.error, tokenExpired: result.tokenExpired },
+        { status: result.statusCode || 500 }
       );
     }
-
-    let data;
-    try {
-      data = await res.json();
-    } catch {
-      const text = await res.text().catch(() => "");
-      console.error("Invalid JSON response from wedge purchase API:", text);
-      return NextResponse.json(
-        { error: "Invalid response from MAM API" },
-        { status: 502 }
-      );
-    }
-
-    // Check if the wedge purchase was successful
-    // MAM API returns success: true/false and may include error message
-    if (data.success === false || data.error) {
-      const errorMsg = data.error || "Unknown error occurred";
-      console.error(`FL wedge purchase failed: ${errorMsg}`);
-      return NextResponse.json(
-        { error: `Failed to use FL wedge: ${errorMsg}` },
-        { status: 400 }
-      );
-    }
-
-    console.log(`Successfully used FL wedge for torrent ${torrentId}`);
-
+    
     return NextResponse.json({ 
       success: true,
       message: "FL wedge applied successfully",
-      torrentId
+      torrentId: result.torrentId
     });
   } catch (err) {
     console.error("Error using FL wedge:", err);

--- a/src/lib/wedge.js
+++ b/src/lib/wedge.js
@@ -1,0 +1,103 @@
+import "server-only";
+import { readMamToken } from "./config.js";
+import { MAM_BASE } from "./constants.js";
+import { generateTimestamp } from "./utilities.js";
+
+/**
+ * Purchase a freeleech wedge for a torrent on MyAnonaMouse
+ * @param {string|number} torrentId - The torrent ID to apply the wedge to
+ * @returns {Promise<{success: boolean, error?: string, tokenExpired?: boolean, statusCode?: number, torrentId?: string}>}
+ */
+export async function purchaseFlWedge(torrentId) {
+  try {
+    // Validate torrentId
+    if (!torrentId) {
+      console.error("[Wedge Service] Validation failed: Torrent ID is required");
+      return {
+        success: false,
+        error: "Torrent ID is required",
+        statusCode: 400
+      };
+    }
+
+    const token = readMamToken();
+    const timestamp = generateTimestamp();
+
+    // Call MAM bonus buy API to purchase freeleech wedge
+    const wedgeUrl = `${MAM_BASE}/json/bonusBuy.php/${timestamp}?spendtype=personalFL&torrentid=${torrentId}&timestamp=${timestamp}`;
+    
+    console.log(`[Wedge Service] Attempting to use FL wedge for torrent ${torrentId}`);
+
+    const res = await fetch(wedgeUrl, {
+      method: "GET",
+      headers: {
+        "Accept": "application/json, text/plain, */*",
+        "Cookie": `mam_id=${token}`,
+        "Origin": "https://www.myanonamouse.net",
+        "Referer": "https://www.myanonamouse.net/"
+      },
+      cache: "no-store"
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      console.error(`[Wedge Service] Failed to purchase FL wedge: ${res.status} - ${text.slice(0, 200)}`);
+      
+      // Check for MAM token expiration
+      if (res.status === 403 && text.toLowerCase().includes("you are not signed in")) {
+        console.error(`[Wedge Service] MAM token has expired for torrent ${torrentId}`);
+        return {
+          success: false,
+          error: "Your MAM token has expired or is invalid. Please update your token.",
+          tokenExpired: true,
+          statusCode: 401
+        };
+      }
+      
+      return {
+        success: false,
+        error: `Failed to purchase FL wedge: ${res.status}`,
+        statusCode: 502
+      };
+    }
+
+    let data;
+    try {
+      data = await res.json();
+    } catch {
+      const text = await res.text().catch(() => "");
+      console.error(`[Wedge Service] Invalid JSON response from wedge purchase API for torrent ${torrentId}:`, text.slice(0, 200));
+      return {
+        success: false,
+        error: "Invalid response from MAM API",
+        statusCode: 502
+      };
+    }
+
+    // Check if the wedge purchase was successful
+    // MAM API returns success: true/false and may include error message
+    if (data.success === false || data.error) {
+      const errorMsg = data.error || "Unknown error occurred";
+      console.error(`[Wedge Service] FL wedge purchase failed for torrent ${torrentId}: ${errorMsg}`);
+      return {
+        success: false,
+        error: `Failed to use FL wedge: ${errorMsg}`,
+        statusCode: 400
+      };
+    }
+
+    console.log(`[Wedge Service] Successfully used FL wedge for torrent ${torrentId}`);
+
+    return { 
+      success: true,
+      torrentId: String(torrentId)
+    };
+  } catch (err) {
+    console.error(`[Wedge Service] Error using FL wedge for torrent ${torrentId}:`, err);
+    return {
+      success: false,
+      error: err?.message || "Failed to use FL wedge",
+      statusCode: 500
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the production bug where FL wedge purchases fail with "fetch failed" error after attempting to download books.

## Problem

The `/api/add` route was making an internal HTTP request to `/api/use-wedge` using `req.nextUrl.origin`. In production, this caused "fetch failed" errors because:
- `req.nextUrl.origin` was undefined or malformed in certain deployment environments
- Self-referential HTTP requests can be blocked by firewalls/security policies
- DNS resolution issues for the server's own hostname

## Solution

Refactored FL wedge logic to use **direct function calls** instead of internal HTTP requests:

1. **Created shared wedge service** (`src/lib/wedge.js`)
   - Extracted core wedge purchase logic into `purchaseFlWedge(torrentId)` function
   - Returns structured response objects instead of HTTP responses
   - Enhanced logging with `[Wedge Service]` prefix

2. **Updated add route** (`app/api/add/route.js`)
   - Replaced `fetch(${req.nextUrl.origin}/api/use-wedge)` with direct `purchaseFlWedge()` call
   - Eliminates dependency on `req.nextUrl.origin`
   - Improved error handling with `tokenExpired` flag

3. **Refactored API route** (`app/api/use-wedge/route.js`)
   - Now uses shared `purchaseFlWedge()` function
   - Maintains backward compatibility as an API endpoint
   - 67% code reduction (98 lines → 32 lines)

4. **Added comprehensive tests** (`__tests__/wedge.test.mjs`)
   - 13 test cases covering all scenarios
   - Service-level testing for better coverage

## Benefits

✅ **Fixes the production bug** - No more "fetch failed" errors  
⚡ **Performance improvement** - Eliminates network roundtrip overhead  
🛡️ **More reliable** - Works in all deployment environments  
📈 **Better code quality** - Net reduction of 58 lines  
🔧 **Easier to maintain** - Shared service can be reused anywhere  
🧪 **Better test coverage** - 208 tests passing  

## Testing

- ✅ All 208 tests passing
- ✅ Unit tests for wedge service
- ✅ Integration tests for add route
- ✅ API route tests maintained
- ✅ No breaking changes

## Changes Summary

```
 __tests__/add.test.mjs       | 100 +++++++++++++++--------
 __tests__/use-wedge.test.mjs |   2 +-
 __tests__/wedge.test.mjs     | 203 ++++++++++++++++++++++++++++++++++
 app/api/add/route.js         |  23 ++---
 app/api/use-wedge/route.js   |  79 ++-------------
 src/lib/wedge.js             | 103 +++++++++++++++++++
 6 files changed, 379 insertions(+), 131 deletions(-)
```

## Deployment Notes

- No environment variable changes required
- No database migrations needed
- Backward compatible with existing API endpoints
- CI/CD tests should pass automatically

## Verification Steps

After deployment:
1. Search for a book on MAM
2. Toggle FL wedge on
3. Click download
4. Verify wedge purchase succeeds
5. Verify book downloads to qBittorrent
6. Check logs for `[Wedge Service]` messages (no "fetch failed" errors)