### PR TITLE
fix: support mousehole v2 state.cookie with fallback to state.currentCookie

### DIFF
--- a/app/api/mam-token/route.js
+++ b/app/api/mam-token/route.js
@@ -24,7 +24,7 @@ export async function GET() {
       try {
         const stateFile = config.mouseholeStateFile;
         const state = JSON.parse(fs.readFileSync(stateFile, "utf8"));
-        const decodedToken = decodeURIComponent(state.currentCookie);
+        const decodedToken = decodeURIComponent(state.cookie ?? state.currentCookie);
         
         return NextResponse.json({
           exists: true,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "email": "masonfox22@gmail.com"
   },
   "private": true,
-  "version": "2.5.3",
+  "version": "2.5.4",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -29,7 +29,7 @@ export function readMamToken() {
       } else {
         const state = JSON.parse(fs.readFileSync(stateFile, "utf8"));
         // URL-decode the token from mousehole's format
-        return decodeURIComponent(state.currentCookie);
+        return decodeURIComponent(state.cookie ?? state.currentCookie);
       }
     } catch (err) {
       console.warn("Failed to read from mousehole, falling back to static token:", err.message);


### PR DESCRIPTION
## Problem

Mousehole v2 renamed the MAM token field in `state.json` from `currentCookie` to `cookie`. Scurry was reading `state.currentCookie` in two places, causing the MAM token lookup to fail for users on mousehole v0.5.0+.

Closes #32

## Changes

- `src/lib/config.js`: use `state.cookie ?? state.currentCookie`
- `app/api/mam-token/route.js`: use `state.cookie ?? state.currentCookie`

The nullish coalescing fallback ensures backwards compatibility with mousehole v1 users who haven't upgraded yet.