### PR TITLE
Show app version in header

### DIFF
--- a/app/components/Header.jsx
+++ b/app/components/Header.jsx
@@ -41,7 +41,7 @@ export default function Header({ onTokenUpdate, mamTokenExists }) {
               href={`https://github.com/masonfox/scurry/releases/tag/v${process.env.NEXT_PUBLIC_APP_VERSION ?? ''}`}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-xs font-normal text-gray-400 dark:text-zinc-500 ml-2.5 mt-1 hover:text-gray-600 dark:hover:text-zinc-300 transition-colors"
+              className="text-xs font-normal text-gray-400 dark:text-zinc-500 ml-2.5 mt-2 hover:text-gray-600 dark:hover:text-zinc-300 transition-colors"
             >
               v{process.env.NEXT_PUBLIC_APP_VERSION ?? '—'}
             </a>

--- a/app/components/Header.jsx
+++ b/app/components/Header.jsx
@@ -37,8 +37,8 @@ export default function Header({ onTokenUpdate, mamTokenExists }) {
               />
             </span>
             <span className="text-gray-800 dark:text-zinc-100">Scurry</span>
-            <span className="text-xs font-normal text-gray-400 dark:text-zinc-500 ml-2.5 mt-2 self-center">
-              v{process.env.NEXT_PUBLIC_APP_VERSION}
+            <span aria-hidden="true" className="text-xs font-normal text-gray-400 dark:text-zinc-500 ml-2.5">
+              v{process.env.NEXT_PUBLIC_APP_VERSION ?? '—'}
             </span>
           </h1>
           <ThemeToggle />

--- a/app/components/Header.jsx
+++ b/app/components/Header.jsx
@@ -37,9 +37,14 @@ export default function Header({ onTokenUpdate, mamTokenExists }) {
               />
             </span>
             <span className="text-gray-800 dark:text-zinc-100">Scurry</span>
-            <span aria-hidden="true" className="text-xs font-normal text-gray-400 dark:text-zinc-500 ml-2.5">
+            <a
+              href={`https://github.com/masonfox/scurry/releases/tag/v${process.env.NEXT_PUBLIC_APP_VERSION ?? ''}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs font-normal text-gray-400 dark:text-zinc-500 ml-2.5 mt-1 hover:text-gray-600 dark:hover:text-zinc-300 transition-colors"
+            >
               v{process.env.NEXT_PUBLIC_APP_VERSION ?? '—'}
-            </span>
+            </a>
           </h1>
           <ThemeToggle />
         </div>

--- a/app/components/Header.jsx
+++ b/app/components/Header.jsx
@@ -38,7 +38,7 @@ export default function Header({ onTokenUpdate, mamTokenExists }) {
             </span>
             <span className="text-gray-800 dark:text-zinc-100">Scurry</span>
             <span className="text-xs font-normal text-gray-400 dark:text-zinc-500 ml-2.5 mt-2 self-center">
-              (v{process.env.NEXT_PUBLIC_APP_VERSION})
+              v{process.env.NEXT_PUBLIC_APP_VERSION}
             </span>
           </h1>
           <ThemeToggle />

--- a/app/components/Header.jsx
+++ b/app/components/Header.jsx
@@ -37,6 +37,9 @@ export default function Header({ onTokenUpdate, mamTokenExists }) {
               />
             </span>
             <span className="text-gray-800 dark:text-zinc-100">Scurry</span>
+            <span className="text-xs font-normal text-gray-400 dark:text-zinc-500 ml-2.5 mt-2 self-center">
+              (v{process.env.NEXT_PUBLIC_APP_VERSION})
+            </span>
           </h1>
           <ThemeToggle />
         </div>

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,10 @@
+import pkg from './package.json' with { type: 'json' };
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  env: {
+    NEXT_PUBLIC_APP_VERSION: pkg.version,
+  },
   // Enable React Compiler for automatic memoization
   reactCompiler: true,
   experimental: {


### PR DESCRIPTION
Displays the current app version in the header next to the Scurry name, using `package.json` as the source of truth.

## Changes
- **`next.config.mjs`**: Imports `package.json` and injects `pkg.version` as the `NEXT_PUBLIC_APP_VERSION` env variable at build time
- **`app/components/Header.jsx`**: Renders a muted `v{version}` label inline after the app name in the `<h1>`

Bumping the `version` field in `package.json` is all that''s needed to keep this up to date.