### PR TITLE
feat: show narrator info for audiobook search results (#31)

### DIFF
--- a/__tests__/search.test.mjs
+++ b/__tests__/search.test.mjs
@@ -36,6 +36,48 @@ describe('search route', () => {
     expect(json.results.length).toBeGreaterThan(0);
   });
 
+  it('includes narrator for audiobook category results', async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [{
+          id: '123', dl: 'abc', title: 'Test', size: '1MB', filetype: 'm4b', added: '2025-08-14',
+          vip: 0, my_snatched: 0, author_info: '{"author":"Author"}', narrator_info: '{"narrator":"Narrator Name"}',
+          seeders: 10, leechers: 2, times_completed: 5
+        }]
+      }),
+      text: async () => "",
+    });
+
+    const req = { url: 'http://localhost/api/search?q=test&category=audiobooks' };
+    const res = await GET(req);
+    const json = await res.json();
+
+    expect(json.results[0].narrator).toBe('Narrator Name');
+  });
+
+  it('omits narrator for book category results', async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [{
+          id: '123', dl: 'abc', title: 'Test', size: '1MB', filetype: 'epub', added: '2025-08-14',
+          vip: 0, my_snatched: 0, author_info: '{"author":"Author"}', narrator_info: '{"narrator":"Narrator Name"}',
+          seeders: 10, leechers: 2, times_completed: 5
+        }]
+      }),
+      text: async () => "",
+    });
+
+    const req = { url: 'http://localhost/api/search?q=test&category=books' };
+    const res = await GET(req);
+    const json = await res.json();
+
+    expect(json.results[0].narrator).toBeNull();
+  });
+
   it('handles search results with missing/null fields', async () => {
     global.fetch.mockResolvedValueOnce({
       ok: true,

--- a/app/api/search/route.js
+++ b/app/api/search/route.js
@@ -90,6 +90,7 @@ export async function GET(req) {
     freeleech: Boolean(item.free == 1),
     snatched: Boolean(item.my_snatched == 1),
     author: parseAuthorInfo(item.author_info),
+    narrator: categoryId === MAM_CATEGORIES.AUDIOBOOKS ? parseAuthorInfo(item.narrator_info) : null,
     seeders: formatNumberWithCommas(item.seeders ?? 0),
     leechers: formatNumberWithCommas(item.leechers ?? 0),
     downloads: formatNumberWithCommas(item.times_completed ?? 0),

--- a/app/components/DownloadReviewModal.jsx
+++ b/app/components/DownloadReviewModal.jsx
@@ -332,7 +332,7 @@ function ItemCard({ item, userStats, hasWedges, isDual, label, tagsEnabled, avai
             )}
           </div>
           <div className="text-xs text-gray-500 dark:text-zinc-400 mt-0.5">
-            by {result.author}
+            by {result.author}{result.narrator && ` · narrated by ${result.narrator}`}
           </div>
         </div>
 

--- a/app/components/DualSearchResultsList.jsx
+++ b/app/components/DualSearchResultsList.jsx
@@ -139,6 +139,7 @@ const resultShape = PropTypes.shape({
   id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   title: PropTypes.string.isRequired,
   author: PropTypes.string.isRequired,
+  narrator: PropTypes.string,
   size: PropTypes.string.isRequired,
   filetypes: PropTypes.string.isRequired,
   seeders: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,

--- a/app/components/SearchResultItem.jsx
+++ b/app/components/SearchResultItem.jsx
@@ -62,9 +62,9 @@ export default function SearchResultItem({ result, onAddItem, selectable = false
                   />
                 </span>
               )}
-              <span>{result.title}</span>
+              <span className="mr-1">{result.title}</span>
               <span className="text-gray-600 dark:text-zinc-400 font-normal">
-                <span className="mx-1">by</span>
+                <span className="mr-1">by</span>
                 <span>{result.author}</span>
                 {result.narrator && <span> ({result.narrator})</span>}
               </span>

--- a/app/components/SearchResultItem.jsx
+++ b/app/components/SearchResultItem.jsx
@@ -66,8 +66,9 @@ export default function SearchResultItem({ result, onAddItem, selectable = false
               <span className="text-gray-600 dark:text-zinc-400 font-normal">
                 <span className="mx-1">by</span>
                 <span>{result.author}</span>
+                {result.narrator && <span> ({result.narrator})</span>}
               </span>
-              <a 
+              <a
                 href={result.torrentUrl}
                 target="_blank" 
                 rel="noopener noreferrer"
@@ -111,6 +112,7 @@ SearchResultItem.propTypes = {
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
     title: PropTypes.string.isRequired,
     author: PropTypes.string.isRequired,
+    narrator: PropTypes.string,
     size: PropTypes.string.isRequired,
     filetypes: PropTypes.string.isRequired,
     seeders: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,

--- a/app/components/SequentialSearchResults.jsx
+++ b/app/components/SequentialSearchResults.jsx
@@ -196,6 +196,7 @@ const resultShape = PropTypes.shape({
   id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   title: PropTypes.string.isRequired,
   author: PropTypes.string.isRequired,
+  narrator: PropTypes.string,
   size: PropTypes.string.isRequired,
   filetypes: PropTypes.string.isRequired,
   seeders: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,


### PR DESCRIPTION
## Summary
- Parses MAM's `narrator_info` field for audiobook search results (mirrors the existing `author_info` handling) and includes it as `narrator` on each result, `null` for books.
- Search result lists show it inline: `by Author (Narrator)`.
- The download review modal/bottomsheet shows the fuller form: `by Author · narrated by Narrator`, since there's more room there.

Closes #31.

## Test plan
- [x] `npx vitest run` — all 267 tests pass, including new coverage for narrator inclusion (audiobooks) and omission (books) in `search.test.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWaWjopKjBYZuxYrJXAHQT